### PR TITLE
Add native Windows ARM 64 Support to GitHub Build Actions

### DIFF
--- a/.github/actions/release-build-windows/action.yml
+++ b/.github/actions/release-build-windows/action.yml
@@ -2,6 +2,10 @@ name: "Build Soia Windows NSIS"
 description: "Shared Windows release build steps"
 
 inputs:
+  arch:
+    description: "Target architecture (x64 or arm64). Drives MPV runtime selection and is used as a cache scope key."
+    required: false
+    default: "x64"
   github_token:
     description: "GitHub token for release API requests"
     required: true
@@ -28,6 +32,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: src-tauri -> target
+        key: ${{ inputs.arch }}
 
     - name: Install pnpm dependencies
       shell: pwsh
@@ -37,6 +42,7 @@ runs:
       shell: pwsh
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        MPV_TARGET_ARCH: ${{ inputs.arch }}
       run: pnpm setup:libs
 
     - name: Build Windows NSIS bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,11 +85,19 @@ jobs:
           compression-level: 0
 
   windows-release:
-    name: Build Windows Packages
-    runs-on: windows-2022
+    name: Build Windows Packages (${{ matrix.package_arch }})
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 50
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-2022
+            package_arch: x64
+          - runner: windows-11-arm
+            package_arch: arm64
     env:
       SOIA_API: ${{ secrets.SOIA_API }}
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -100,10 +108,13 @@ jobs:
       - name: Build Soia Windows bundle (shared steps)
         uses: ./.github/actions/release-build-windows
         with:
+          arch: ${{ matrix.package_arch }}
           github_token: ${{ github.token }}
 
       - name: Prepare release assets
         shell: pwsh
+        env:
+          PACKAGE_ARCH: ${{ matrix.package_arch }}
         run: |
           if ([string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY)) {
             throw "TAURI_SIGNING_PRIVATE_KEY is required for updater signatures"
@@ -111,6 +122,7 @@ jobs:
 
           New-Item -ItemType Directory -Path release -Force | Out-Null
           $tag = "${{ github.ref_name }}"
+          $arch = $env:PACKAGE_ARCH
           $sources = Get-ChildItem -Path "src-tauri/target/release/bundle/nsis/*.exe"
           if ($sources.Count -eq 0) {
             throw "No NSIS installer found under src-tauri/target/release/bundle/nsis"
@@ -120,13 +132,13 @@ jobs:
             throw "Expected exactly one NSIS installer, found $($sources.Count):`n$names"
           }
           $source = $sources[0]
-          $target = "release/Soia-$tag-Windows-x64-setup.exe"
+          $target = "release/Soia-$tag-Windows-$arch-setup.exe"
           Copy-Item $source.FullName $target
           $hash = (Get-FileHash -Path $target -Algorithm SHA256).Hash.ToLower()
           "$hash  $([System.IO.Path]::GetFileName($target))" | Set-Content -Path "$target.sha256" -NoNewline
           pnpm tauri signer sign $target
 
-          $portableTarget = "release/Soia-$tag-Windows-x64-portable.zip"
+          $portableTarget = "release/Soia-$tag-Windows-$arch-portable.zip"
           $portableStaging = "release/portable"
           if (Test-Path $portableStaging) {
             Remove-Item -Path $portableStaging -Recurse -Force
@@ -177,7 +189,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: soia-release-${{ github.ref_name }}-windows-x64
+          name: soia-release-${{ github.ref_name }}-windows-${{ matrix.package_arch }}
           path: release/*
           compression-level: 0
 
@@ -289,6 +301,7 @@ jobs:
           MAC_ARM_FILE="Soia-${TAG}-macOS-arm64.app.tar.gz"
           MAC_X64_FILE="Soia-${TAG}-macOS-x64.app.tar.gz"
           WIN_X64_FILE="Soia-${TAG}-Windows-x64-setup.exe"
+          WIN_ARM_FILE="Soia-${TAG}-Windows-arm64-setup.exe"
           LINUX_X64_FILE="Soia-${TAG}-Linux-x64-wayland.deb"
           LINUX_ARM_FILE="Soia-${TAG}-Linux-arm64-wayland.deb"
           NOTES="$(awk -v version="$VERSION" '
@@ -309,6 +322,7 @@ jobs:
             "release/${MAC_ARM_FILE}.sig" \
             "release/${MAC_X64_FILE}.sig" \
             "release/${WIN_X64_FILE}.sig" \
+            "release/${WIN_ARM_FILE}.sig" \
             "release/${LINUX_X64_FILE}.sig" \
             "release/${LINUX_ARM_FILE}.sig"; do
             if [ ! -f "$sig" ]; then
@@ -324,11 +338,13 @@ jobs:
             --arg mac_arm_url "${BASE_URL}/${MAC_ARM_FILE}" \
             --arg mac_x64_url "${BASE_URL}/${MAC_X64_FILE}" \
             --arg win_x64_url "${BASE_URL}/${WIN_X64_FILE}" \
+            --arg win_arm_url "${BASE_URL}/${WIN_ARM_FILE}" \
             --arg linux_x64_url "${BASE_URL}/${LINUX_X64_FILE}" \
             --arg linux_arm_url "${BASE_URL}/${LINUX_ARM_FILE}" \
             --rawfile mac_arm_sig "release/${MAC_ARM_FILE}.sig" \
             --rawfile mac_x64_sig "release/${MAC_X64_FILE}.sig" \
             --rawfile win_x64_sig "release/${WIN_X64_FILE}.sig" \
+            --rawfile win_arm_sig "release/${WIN_ARM_FILE}.sig" \
             --rawfile linux_x64_sig "release/${LINUX_X64_FILE}.sig" \
             --rawfile linux_arm_sig "release/${LINUX_ARM_FILE}.sig" \
             '{
@@ -339,6 +355,7 @@ jobs:
                 "darwin-aarch64": { signature: $mac_arm_sig, url: $mac_arm_url },
                 "darwin-x86_64": { signature: $mac_x64_sig, url: $mac_x64_url },
                 "windows-x86_64": { signature: $win_x64_sig, url: $win_x64_url },
+                "windows-aarch64": { signature: $win_arm_sig, url: $win_arm_url },
                 "linux-x86_64": { signature: $linux_x64_sig, url: $linux_x64_url },
                 "linux-aarch64": { signature: $linux_arm_sig, url: $linux_arm_url }
               }
@@ -353,6 +370,8 @@ jobs:
           MAC_X64_DMG="Soia-${TAG}-macOS-x64.dmg"
           WIN_X64_SETUP="Soia-${TAG}-Windows-x64-setup.exe"
           WIN_X64_PORTABLE="Soia-${TAG}-Windows-x64-portable.zip"
+          WIN_ARM_SETUP="Soia-${TAG}-Windows-arm64-setup.exe"
+          WIN_ARM_PORTABLE="Soia-${TAG}-Windows-arm64-portable.zip"
           LINUX_X64_DEB="Soia-${TAG}-Linux-x64-wayland.deb"
           LINUX_X64_APPIMAGE="Soia-${TAG}-Linux-x64-wayland.AppImage"
           LINUX_ARM_DEB="Soia-${TAG}-Linux-arm64-wayland.deb"
@@ -375,6 +394,7 @@ jobs:
             echo "| macOS (Apple silicon) | [\`${MAC_ARM_DMG}\`](${BASE_URL}/${MAC_ARM_DMG}) |"
             echo "| macOS (Intel) | [\`${MAC_X64_DMG}\`](${BASE_URL}/${MAC_X64_DMG}) |"
             echo "| Windows (x64, Installer) | [\`${WIN_X64_SETUP}\`](${BASE_URL}/${WIN_X64_SETUP}) |"
+            echo "| Windows (arm64, Installer) | [\`${WIN_ARM_SETUP}\`](${BASE_URL}/${WIN_ARM_SETUP}) |"
             echo "| Linux (x64, Wayland, DEB) | [\`${LINUX_X64_DEB}\`](${BASE_URL}/${LINUX_X64_DEB}) |"
             echo "| Linux (arm64, Wayland, DEB) | [\`${LINUX_ARM_DEB}\`](${BASE_URL}/${LINUX_ARM_DEB}) |"
             echo
@@ -385,6 +405,7 @@ jobs:
             echo "| Platform | Download |"
             echo "| --- | --- |"
             echo "| Windows (x64, Portable) | [\`${WIN_X64_PORTABLE}\`](${BASE_URL}/${WIN_X64_PORTABLE}) |"
+            echo "| Windows (arm64, Portable) | [\`${WIN_ARM_PORTABLE}\`](${BASE_URL}/${WIN_ARM_PORTABLE}) |"
             echo "| Linux (x64, Wayland) | [\`${LINUX_X64_APPIMAGE}\`](${BASE_URL}/${LINUX_X64_APPIMAGE}) |"
             echo "| Linux (arm64, Wayland) | [\`${LINUX_ARM_APPIMAGE}\`](${BASE_URL}/${LINUX_ARM_APPIMAGE}) |"
           } >> release/RELEASE_BODY.md

--- a/scripts/runtime_libs_release_config.env
+++ b/scripts/runtime_libs_release_config.env
@@ -1,4 +1,4 @@
 # Shared defaults for mpv runtime bundle resolution across platforms.
 # Override at runtime with environment variables MPV_RELEASE_REPO / MPV_RELEASE_TAG when needed.
 MPV_RELEASE_REPO=FengZeng/mpv
-MPV_RELEASE_TAG=v0.41.0-r8
+MPV_RELEASE_TAG=v0.41.0-r10

--- a/scripts/setup_runtime_libs_windows.mjs
+++ b/scripts/setup_runtime_libs_windows.mjs
@@ -172,13 +172,14 @@ function selectAssetUrl(releaseJson, explicitUrl) {
   );
   if (candidate) return candidate;
 
-  candidate = urls.find((url) => isWindowsAsset(url) && hasSupportedExtension(url));
-  if (candidate) return candidate;
-
-  candidate = urls.find((url) => hasSupportedExtension(url));
-  if (candidate) return candidate;
-
-  return "";
+  const available = urls
+    .map((url) => basename(url.split("?")[0]))
+    .join(", ");
+  throw new Error(
+    `[ERROR] No Windows ${arch.name} asset found in release. ` +
+      `Provide an asset whose name matches ${arch.pattern} (or 'universal'/'all'). ` +
+      `Available assets: ${available || "(none)"}`
+  );
 }
 
 async function downloadAsset(assetUrl, outputFile) {


### PR DESCRIPTION
With the rising popularity of Windows ARM 64 devices, such as the latest Surface / Snapdragon X laptops, recently released Snapdragon X2 devices and soon to be released Nvidia N1X SOC users are increasingly expecting native applications.

Built and tested the GitHub build Windows ARM artifacts (both zip and installer) from my fork using my Snapdragon X2 Elite Extreme based Asus Zenbook A16 running Windows 11 ARM 26H1. 

Here's a screenshot showing Soia running natively on my system: 

<img width="1082" height="520" alt="image" src="https://github.com/user-attachments/assets/8cde21c0-069c-4234-8e44-bfb11a418012" />
