### PR TITLE
Improve fullscreen window handling on Windows platform

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4405,6 +4405,7 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
+ "windows-sys 0.61.2",
  "zip",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,6 +68,9 @@ objc2-metal = "0.3.1"
 objc2-quartz-core = "0.3.1"
 block2 = "0.6.1"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_UI_WindowsAndMessaging"] }
+
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -30,3 +30,10 @@ pub(crate) fn sync_mpv_render_target(
 ) -> Result<(), String> {
     crate::app_bootstrap::sync_mpv_render_target_to_window(&window)
 }
+
+#[tauri::command]
+pub(crate) async fn prepare_window_for_fullscreen(
+    window: tauri::WebviewWindow,
+) -> Result<bool, String> {
+    crate::platform::prepare_window_for_fullscreen(window).await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -562,6 +562,7 @@ pub fn run() {
             commands::window::apply_window_appearance,
             commands::window::set_window_vibrancy_visible,
             commands::window::sync_mpv_render_target,
+            commands::window::prepare_window_for_fullscreen,
             commands::platform::is_native_pip_enabled,
             commands::platform::set_native_pip_enabled,
             commands::playback::get_runtime_versions,

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -265,6 +265,21 @@ pub(crate) fn enforce_native_pip_aspect(
     }
 }
 
+pub(crate) async fn prepare_window_for_fullscreen(
+    window: tauri::WebviewWindow,
+) -> Result<bool, String> {
+    #[cfg(target_os = "windows")]
+    {
+        return windows::prepare_window_for_fullscreen(window).await;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = window;
+        Ok(false)
+    }
+}
+
 #[cfg(target_os = "macos")]
 pub(crate) fn sync_mpv_metal_layer_geometry(window: &tauri::WebviewWindow, utils: usize) {
     macos::sync_mpv_metal_layer_geometry(window, utils);

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -1,10 +1,16 @@
 #[cfg(target_os = "windows")]
 mod imp {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use std::sync::mpsc;
     use std::sync::{Mutex, OnceLock};
+    use std::time::{Duration, Instant};
     use tauri::{Emitter, Manager};
+    use tokio::time::sleep;
+    use windows_sys::Win32::UI::WindowsAndMessaging::IsZoomed;
 
     const MAIN_WINDOW_LABEL: &str = "main";
+    const WINDOW_STATE_POLL_INTERVAL: Duration = Duration::from_millis(10);
+    const WINDOW_STATE_SETTLE_TIMEOUT: Duration = Duration::from_secs(2);
     const PIP_DEFAULT_ASPECT: f64 = 16.0 / 9.0;
     const PIP_MIN_WIDTH: u32 = 300;
     const PIP_MAX_WIDTH: u32 = 720;
@@ -52,6 +58,36 @@ mod imp {
 
     fn as_i32(value: u32) -> i32 {
         i32::try_from(value).unwrap_or(i32::MAX)
+    }
+
+    fn is_native_window_maximized(window: &tauri::WebviewWindow) -> Result<bool, String> {
+        let handle = window.window_handle().map_err(|error| error.to_string())?;
+        let hwnd = match handle.as_raw() {
+            RawWindowHandle::Win32(handle) => handle.hwnd.get() as usize as *mut std::ffi::c_void,
+            _ => return Err("Main window does not expose a Win32 window handle".into()),
+        };
+        Ok(unsafe { IsZoomed(hwnd) != 0 })
+    }
+
+    async fn wait_for_window_to_unmaximize(window: &tauri::WebviewWindow) -> Result<(), String> {
+        let deadline = Instant::now() + WINDOW_STATE_SETTLE_TIMEOUT;
+        let mut settled_samples = 0;
+        loop {
+            let native_maximized = is_native_window_maximized(window)?;
+            let tauri_maximized = window.is_maximized().map_err(|error| error.to_string())?;
+            if !native_maximized && !tauri_maximized {
+                settled_samples += 1;
+                if settled_samples >= 2 {
+                    return Ok(());
+                }
+            } else {
+                settled_samples = 0;
+            }
+            if Instant::now() >= deadline {
+                return Err("Timed out waiting for the maximized window to restore".into());
+            }
+            sleep(WINDOW_STATE_POLL_INTERVAL).await;
+        }
     }
 
     fn current_aspect_ratio() -> f64 {
@@ -257,6 +293,25 @@ mod imp {
             .unwrap_or(false)
     }
 
+    pub(crate) async fn prepare_window_for_fullscreen(
+        window: tauri::WebviewWindow,
+    ) -> Result<bool, String> {
+        // Tauri updates its cached maximize flag from WM_SIZE, which can lag
+        // behind the real Win32 state during a maximize/restore transition.
+        let was_maximized =
+            is_native_window_maximized(&window)? || window.is_maximized().unwrap_or(false);
+        if !was_maximized {
+            return Ok(false);
+        }
+
+        window.unmaximize().map_err(|error| error.to_string())?;
+        if let Err(error) = wait_for_window_to_unmaximize(&window).await {
+            let _ = window.maximize();
+            return Err(error);
+        }
+        Ok(true)
+    }
+
     pub(crate) fn set_native_pip_enabled(
         app_handle: &tauri::AppHandle,
         enabled: bool,
@@ -329,5 +384,5 @@ mod imp {
 #[cfg(target_os = "windows")]
 pub(crate) use imp::{
     enforce_native_pip_aspect, is_native_pip_enabled, set_native_pip_enabled,
-    update_native_pip_state,
+    prepare_window_for_fullscreen, update_native_pip_state,
 };

--- a/src/composables/usePlaybackCommands.ts
+++ b/src/composables/usePlaybackCommands.ts
@@ -18,6 +18,7 @@ type PlayerEffectState = {
 
 type CurrentWindow = {
   isFullscreen: () => Promise<boolean>;
+  maximize: () => Promise<void>;
   setFullscreen: (value: boolean) => Promise<void>;
 };
 
@@ -60,10 +61,12 @@ export const usePlaybackCommands = (
   state: PlayerEffectState,
   currentWindow: CurrentWindow,
   coreClient: CoreClient,
+  isWindowsPlatform = false,
 ) => {
   let lastAudibleVolume = 100;
   let volumeApplyQueue: Promise<void> = Promise.resolve();
   let volumeRequestId = 0;
+  let restoreMaximizedAfterFullscreen = false;
 
   const MEDIA_FILES_FILTER = [
     {
@@ -155,8 +158,36 @@ export const usePlaybackCommands = (
 
   const toggleFullscreen = async (): Promise<void> => {
     const isFull = await currentWindow.isFullscreen();
-    await currentWindow.setFullscreen(!isFull);
-    state.window.isFullscreen = !isFull;
+    if (isFull) {
+      const shouldRestoreMaximized = restoreMaximizedAfterFullscreen;
+      restoreMaximizedAfterFullscreen = false;
+      try {
+        await currentWindow.setFullscreen(false);
+      } catch (error) {
+        restoreMaximizedAfterFullscreen = shouldRestoreMaximized;
+        throw error;
+      }
+      state.window.isFullscreen = false;
+      if (shouldRestoreMaximized) {
+        await currentWindow.maximize();
+      }
+      return;
+    }
+
+    const wasMaximized =
+      isWindowsPlatform &&
+      (await invoke<boolean>("prepare_window_for_fullscreen"));
+    restoreMaximizedAfterFullscreen = wasMaximized;
+    try {
+      await currentWindow.setFullscreen(true);
+    } catch (error) {
+      restoreMaximizedAfterFullscreen = false;
+      if (wasMaximized) {
+        await currentWindow.maximize().catch(() => {});
+      }
+      throw error;
+    }
+    state.window.isFullscreen = true;
   };
 
   type MpvArg = string | number | boolean;
@@ -169,7 +200,17 @@ export const usePlaybackCommands = (
   };
 
   const syncFullscreen = async (): Promise<void> => {
-    state.window.isFullscreen = await currentWindow.isFullscreen();
+    const isFullscreen = await currentWindow.isFullscreen();
+    const exitedFullscreen = state.window.isFullscreen && !isFullscreen;
+    state.window.isFullscreen = isFullscreen;
+    if (
+      isWindowsPlatform &&
+      exitedFullscreen &&
+      restoreMaximizedAfterFullscreen
+    ) {
+      restoreMaximizedAfterFullscreen = false;
+      await currentWindow.maximize();
+    }
   };
 
   const syncMpvRenderTarget = async (): Promise<void> => {

--- a/src/composables/usePlaybackController.ts
+++ b/src/composables/usePlaybackController.ts
@@ -62,6 +62,8 @@ export type PlayerApi = {
 
 export const usePlaybackController = (coreClient: CoreClient): PlayerApi => {
   const currentWindow = Window.getCurrent();
+  const isWindowsPlatform =
+    typeof navigator !== "undefined" && /\bwindows\b/i.test(navigator.userAgent);
 
   const state = reactive<PlayerState>({
     media: {
@@ -104,7 +106,12 @@ export const usePlaybackController = (coreClient: CoreClient): PlayerApi => {
     return Boolean(nextUrl) && nextUrl !== state.media.lastLoadedUrl;
   });
 
-  const commands = usePlaybackCommands(state, currentWindow, coreClient);
+  const commands = usePlaybackCommands(
+    state,
+    currentWindow,
+    coreClient,
+    isWindowsPlatform,
+  );
 
   return {
     state,


### PR DESCRIPTION
This pull request introduces improved fullscreen handling for Windows, ensuring that maximized windows can enter fullscreen correctly. The changes add platform-specific logic to detect and manage the maximized state, update both the backend (Rust) and frontend (TypeScript) code, and ensure robust error handling during window state transitions.

**Windows-specific fullscreen/maximize handling:**

* Added a new Tauri command (`prepare_window_for_fullscreen`) that checks if the window is maximized on Windows, unmaximizes it before entering fullscreen, and tracks if it should be restored after exiting fullscreen (`src-tauri/src/platform/windows.rs`, `src-tauri/src/platform/mod.rs`, `src-tauri/src/commands/window.rs`, `src-tauri/src/lib.rs`) [[1]](diffhunk://#diff-6ac41cfbb115d3d0d4a33eac2959abc5776b4f93e33eab343b9c9bcd2914bdf7R296-R314) [[2]](diffhunk://#diff-c9cb12dd26ff6f8b95604bc6d20f37ff1fb828ce1b37457301716e2ace90f1c1R268-R282) [[3]](diffhunk://#diff-cfd8dedd2b812de320ed1bd328be4778a3b6585e4531c20a97639ce8cee5f4f0R33-R39) [[4]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR565).
* Updated dependencies to include `windows-sys` for Windows API access (`src-tauri/Cargo.toml`).

**Frontend integration and state management:**

* Extended the window interface and playback commands to support maximize/restore logic, and added platform detection for Windows (`src/composables/usePlaybackCommands.ts`, `src/composables/usePlaybackController.ts`) [[1]](diffhunk://#diff-5f1e614fef83d432287577d247ad37454f83c8f12c90297064e9240ecbff35b2R21) [[2]](diffhunk://#diff-5f1e614fef83d432287577d247ad37454f83c8f12c90297064e9240ecbff35b2R64-R69) [[3]](diffhunk://#diff-a4ffa3d50debaa19cd5b138ab2277ca36509cce543ff6c9322ef5793200738c3R65-R66) [[4]](diffhunk://#diff-a4ffa3d50debaa19cd5b138ab2277ca36509cce543ff6c9322ef5793200738c3L107-R114).
* Enhanced `toggleFullscreen` and `syncFullscreen` to restore the maximized state after exiting fullscreen, with robust error handling to avoid leaving the window in an inconsistent state (`src/composables/usePlaybackCommands.ts`) [[1]](diffhunk://#diff-5f1e614fef83d432287577d247ad37454f83c8f12c90297064e9240ecbff35b2L158-R190) [[2]](diffhunk://#diff-5f1e614fef83d432287577d247ad37454f83c8f12c90297064e9240ecbff35b2L172-R213).

These changes ensure a seamless user experience when toggling fullscreen on Windows, preserving the user's window state and preventing UI glitches.