### PR TITLE
feat(audio): implement 3D virtual surround sound and audio filters

### DIFF
--- a/src-tauri/src/store/ui_state_store.rs
+++ b/src-tauri/src/store/ui_state_store.rs
@@ -39,6 +39,8 @@ pub struct UiState {
     #[serde(default)]
     pub audio: Option<crate::audio_output::AudioSettings>,
     #[serde(default)]
+    pub surround_sound: Option<SurroundSoundState>,
+    #[serde(default)]
     pub playback_adjustments: Option<PlaybackAdjustmentsState>,
     #[serde(default)]
     pub playback: Option<PlaybackState>,
@@ -65,6 +67,7 @@ impl Default for UiState {
             settings: None,
             rendering: None,
             audio: None,
+            surround_sound: None,
             playback_adjustments: None,
             playback: None,
             subtitle_appearance: None,
@@ -86,6 +89,12 @@ impl UiState {
             settings: incoming.settings.or(self.settings),
             rendering: incoming.rendering.or(self.rendering),
             audio: incoming.audio.or(self.audio),
+            surround_sound: match (self.surround_sound, incoming.surround_sound) {
+                (Some(curr), Some(inc)) => Some(curr.merge(inc)),
+                (None, Some(inc)) => Some(inc),
+                (Some(curr), None) => Some(curr),
+                (None, None) => None,
+            },
             playback_adjustments: incoming
                 .playback_adjustments
                 .or(self.playback_adjustments),
@@ -144,6 +153,42 @@ pub struct ColorAdjustmentsState {
     pub gamma: Option<f64>,
     #[serde(default)]
     pub hue: Option<f64>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SurroundSoundState {
+    #[serde(default)]
+    pub global_enabled: Option<bool>,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub preset: Option<String>,
+    #[serde(default)]
+    pub surround_depth: Option<f64>,
+    #[serde(default)]
+    pub ambience: Option<f64>,
+    #[serde(default)]
+    pub clarity: Option<f64>,
+    #[serde(default)]
+    pub bass_boost: Option<f64>,
+    #[serde(default)]
+    pub dynamic_boost: Option<f64>,
+}
+
+impl SurroundSoundState {
+    fn merge(self, incoming: SurroundSoundState) -> SurroundSoundState {
+        SurroundSoundState {
+            global_enabled: incoming.global_enabled.or(self.global_enabled),
+            enabled: incoming.enabled.or(self.enabled),
+            preset: incoming.preset.or(self.preset),
+            surround_depth: incoming.surround_depth.or(self.surround_depth),
+            ambience: incoming.ambience.or(self.ambience),
+            clarity: incoming.clarity.or(self.clarity),
+            bass_boost: incoming.bass_boost.or(self.bass_boost),
+            dynamic_boost: incoming.dynamic_boost.or(self.dynamic_boost),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,6 +36,7 @@ import { usePlaylistCreationPrompt } from "./composables/usePlaylistCreationProm
 import { usePlaybackContextMenu } from "./composables/usePlaybackContextMenu";
 import { useRemoteControlQrDialog } from "./composables/useRemoteControlQrDialog";
 import { useAudioOutput } from "./composables/useAudioOutput";
+import { useSurroundSound } from "./composables/useSurroundSound";
 import { tauriCoreClient } from "./core-client/tauriPlaybackClient";
 import { tauriPlaylistSourceClient } from "./core-client/tauriPlaylistSourceClient";
 
@@ -65,6 +66,7 @@ const {
     isPipEnabled,
     schedulePointerRefresh,
     shouldKeepControlsVisible,
+    showSurroundMenu,
     hideAllMenus,
     toggleMenu,
     closeAllMenus,
@@ -82,6 +84,11 @@ const {
     setWindowControlsVisible,
     normalizeStoredPanel,
 } = useAppBootstrap(tauriCoreClient);
+
+const {
+    applySurroundForMedia,
+    reapplyFilters: reapplySurround,
+} = useSurroundSound();
 
 const clearNavSelectionDuringLoad = ref(false);
 const playbackLoadingState = usePlaybackLoadingState();
@@ -455,6 +462,7 @@ const onFileLoaded = async () => {
         await tracks.setSubtitlesDisabled(true);
     }
     await adjustments.applyColorAdjustmentsForMedia(player.state.media.url);
+    await applySurroundForMedia(player.state.media.url);
     await subtitleAppearance.applySubtitleAppearanceOptions();
 };
 
@@ -704,6 +712,7 @@ useAppStartupBindings({
             :playback-rates="speed.playbackRates"
             :show-speed-menu="speed.showSpeedMenu.value"
             :show-settings-menu="adjustments.showSettingsMenu.value"
+            :show-surround-menu="showSurroundMenu"
             :audio-delay="adjustments.audioDelay.value"
             :sub-delay="adjustments.subDelay.value"
             :secondary-sub-delay="adjustments.secondarySubDelay.value"

--- a/src/components/PlayerControls.vue
+++ b/src/components/PlayerControls.vue
@@ -23,6 +23,7 @@ const props = defineProps<{
     playbackRates: number[];
     showSpeedMenu: boolean;
     showSettingsMenu: boolean;
+    showSurroundMenu: boolean;
     audioDelay: number;
     subDelay: number;
     secondarySubDelay: number;
@@ -60,7 +61,10 @@ const emit = defineEmits<{
     (e: "toggle-play-pause"): void;
     (e: "stop-playback"): void;
     (e: "next-track"): void;
-    (e: "toggle-menu", menuName: "audio" | "sub" | "speed" | "settings"): void;
+    (
+        e: "toggle-menu",
+        menuName: "audio" | "sub" | "speed" | "settings" | "surround",
+    ): void;
     (e: "toggle-loop-one"): void;
     (e: "set-speed", rate: number): void;
     (e: "set-speed-continuously", rate: number): void;
@@ -253,6 +257,7 @@ onUnmounted(() => {
                         :playback-rates="playbackRates"
                         :show-speed-menu="showSpeedMenu"
                         :show-settings-menu="showSettingsMenu"
+                        :show-surround-menu="showSurroundMenu"
                         :speed-locked="audioPassthroughActive"
                         :audio-delay="audioDelay"
                         :sub-delay="subDelay"

--- a/src/components/player-controls/RightControls.vue
+++ b/src/components/player-controls/RightControls.vue
@@ -13,12 +13,17 @@ import {
     getSubtitleTrackTitle,
 } from "../../utils/trackDisplay";
 import ControlSlider from "./ControlSlider.vue";
+import {
+    useSurroundSound,
+    type SurroundPreset,
+} from "../../composables/useSurroundSound";
 
 const props = defineProps<{
     currentSpeed: number;
     playbackRates: number[];
     showSpeedMenu: boolean;
     showSettingsMenu: boolean;
+    showSurroundMenu: boolean;
     speedLocked: boolean;
     audioDelay: number;
     subDelay: number;
@@ -52,7 +57,10 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-    (e: "toggle-menu", menuName: "audio" | "sub" | "speed" | "settings"): void;
+    (
+        e: "toggle-menu",
+        menuName: "audio" | "sub" | "speed" | "settings" | "surround",
+    ): void;
     (e: "toggle-loop-one"): void;
     (e: "set-speed", rate: number): void;
     (e: "set-speed-continuously", rate: number): void;
@@ -114,6 +122,16 @@ const subtitleFontOptions = [
 
 const isSameTrackId = (left: MediaTrack["id"], right: MediaTrack["id"]) =>
     String(left) === String(right);
+
+const showSurroundMenu = computed(() => props.showSurroundMenu);
+const {
+    surroundState,
+    globalSurroundEnabled,
+    setGlobalSurroundEnabled,
+    setEnabled: setSurroundEnabled,
+    setPreset: setSurroundPreset,
+    setParam: setSurroundParam,
+} = useSurroundSound();
 const activeSubTarget = computed(() => props.activeSubTarget);
 const activeSubFontFamily = computed(() =>
     props.primarySubFontFamily,
@@ -941,6 +959,212 @@ watch(
                             @change="emit('set-hue', $event)"
                             @reset="emit('set-hue', 0)"
                         />
+                    </div>
+                </div>
+            </transition>
+        </div>
+
+        <div class="track-menu-container">
+            <button
+                class="icon-button icon-button--player"
+                @click.stop="emit('toggle-menu', 'surround')"
+                title="3D Audio"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="settings-icon"
+                    viewBox="0 0 24 24"
+                    width="20px"
+                    height="20px"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.8"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                >
+                    <path d="M7 7.5a6.5 6.5 0 0 0 0 9" />
+                    <path d="M4 4.5a11 11 0 0 0 0 15" />
+                    <path d="M17 7.5a6.5 6.5 0 0 1 0 9" />
+                    <path d="M20 4.5a11 11 0 0 1 0 15" />
+                    <text
+                        x="12"
+                        y="14.5"
+                        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
+                        font-size="7.5"
+                        font-weight="900"
+                        fill="currentColor"
+                        stroke="none"
+                        text-anchor="middle"
+                        letter-spacing="-0.3px"
+                    >
+                        3D
+                    </text>
+                </svg>
+            </button>
+
+            <transition name="fade-up">
+                <div v-if="showSurroundMenu" class="track-menu track-menu--settings track-menu--surround">
+                    <div class="track-menu__header">
+                        <span>3D Audio</span>
+                        <div class="track-menu__header-actions">
+                            <button
+                                class="track-menu__mode-toggle"
+                                type="button"
+                                :aria-pressed="globalSurroundEnabled"
+                                :title="
+                                    globalSurroundEnabled
+                                        ? 'Global apply enabled'
+                                        : 'Enable global apply'
+                                "
+                                @click.stop="
+                                    setGlobalSurroundEnabled(
+                                        !globalSurroundEnabled,
+                                    )
+                                "
+                            >
+                                <span class="track-menu__mode-label">Global</span>
+                                <span
+                                    class="track-menu__mode-switch"
+                                    :class="{
+                                        'track-menu__mode-switch--on':
+                                            globalSurroundEnabled,
+                                    }"
+                                >
+                                    <span class="track-menu__mode-thumb"></span>
+                                </span>
+                            </button>
+                            <button
+                                class="track-menu__mode-toggle"
+                                type="button"
+                                :aria-pressed="surroundState.enabled"
+                                :title="
+                                    surroundState.enabled
+                                        ? '3D Audio enabled'
+                                        : 'Enable 3D Audio'
+                                "
+                                @click.stop="
+                                    setSurroundEnabled(!surroundState.enabled)
+                                "
+                            >
+                                <span class="track-menu__mode-label">Enable</span>
+                                <span
+                                    class="track-menu__mode-switch"
+                                    :class="{
+                                        'track-menu__mode-switch--on':
+                                            surroundState.enabled,
+                                    }"
+                                >
+                                    <span class="track-menu__mode-thumb"></span>
+                                </span>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="track-menu__list track-menu__list--settings panel__surround-body">
+                        <!-- Presets -->
+                        <div class="panel__surround-presets">
+                            <button
+                                v-for="key in (['movies', 'music', 'gaming'] as const)"
+                                :key="key"
+                                type="button"
+                                class="panel__surround-preset"
+                                :class="{ 'panel__surround-preset--active': surroundState.preset === key }"
+                                @click="setSurroundPreset(key as SurroundPreset)"
+                            >
+                                {{ key.charAt(0).toUpperCase() + key.slice(1) }}
+                            </button>
+                            <button
+                                type="button"
+                                class="panel__surround-preset"
+                                :class="{ 'panel__surround-preset--active': surroundState.preset === 'custom' }"
+                                @click="setSurroundPreset('custom')"
+                            >
+                                Custom
+                            </button>
+                        </div>
+
+                        <!-- Sliders -->
+                        <div class="panel__surround-sliders">
+                            <div class="panel__surround-row">
+                                <div class="panel__surround-label-col">
+                                    <span class="panel__surround-label">Surround Depth</span>
+                                    <span class="panel__surround-hint">Stereo field width</span>
+                                </div>
+                                <input
+                                    type="range"
+                                    min="0"
+                                    max="100"
+                                    class="panel__surround-slider"
+                                    :value="surroundState.surroundDepth"
+                                    @input="setSurroundParam('surroundDepth', Number(($event.target as HTMLInputElement).value))"
+                                />
+                                <span class="panel__surround-value">{{ surroundState.surroundDepth }}</span>
+                            </div>
+
+                            <div class="panel__surround-row">
+                                <div class="panel__surround-label-col">
+                                    <span class="panel__surround-label">Ambience</span>
+                                    <span class="panel__surround-hint">Room reverb / echo</span>
+                                </div>
+                                <input
+                                    type="range"
+                                    min="0"
+                                    max="100"
+                                    class="panel__surround-slider"
+                                    :value="surroundState.ambience"
+                                    @input="setSurroundParam('ambience', Number(($event.target as HTMLInputElement).value))"
+                                />
+                                <span class="panel__surround-value">{{ surroundState.ambience }}</span>
+                            </div>
+
+                            <div class="panel__surround-row">
+                                <div class="panel__surround-label-col">
+                                    <span class="panel__surround-label">Clarity</span>
+                                    <span class="panel__surround-hint">Treble presence</span>
+                                </div>
+                                <input
+                                    type="range"
+                                    min="0"
+                                    max="100"
+                                    class="panel__surround-slider"
+                                    :value="surroundState.clarity"
+                                    @input="setSurroundParam('clarity', Number(($event.target as HTMLInputElement).value))"
+                                />
+                                <span class="panel__surround-value">{{ surroundState.clarity }}</span>
+                            </div>
+
+                            <div class="panel__surround-row">
+                                <div class="panel__surround-label-col">
+                                    <span class="panel__surround-label">Bass Boost</span>
+                                    <span class="panel__surround-hint">Low-frequency gain</span>
+                                </div>
+                                <input
+                                    type="range"
+                                    min="0"
+                                    max="100"
+                                    class="panel__surround-slider"
+                                    :value="surroundState.bassBoost"
+                                    @input="setSurroundParam('bassBoost', Number(($event.target as HTMLInputElement).value))"
+                                />
+                                <span class="panel__surround-value">{{ surroundState.bassBoost }}</span>
+                            </div>
+
+                            <div class="panel__surround-row">
+                                <div class="panel__surround-label-col">
+                                    <span class="panel__surround-label">Dynamic Boost</span>
+                                    <span class="panel__surround-hint">Loudness levelling</span>
+                                </div>
+                                <input
+                                    type="range"
+                                    min="0"
+                                    max="100"
+                                    class="panel__surround-slider"
+                                    :value="surroundState.dynamicBoost"
+                                    @input="setSurroundParam('dynamicBoost', Number(($event.target as HTMLInputElement).value))"
+                                />
+                                <span class="panel__surround-value">{{ surroundState.dynamicBoost }}</span>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </transition>

--- a/src/composables/useAppBootstrap.ts
+++ b/src/composables/useAppBootstrap.ts
@@ -71,11 +71,8 @@ export const useAppBootstrap = (coreClient: CoreClient) => {
     const shouldKeepControlsVisible = () =>
         isPointerOverUi.value || (isMacOS && isPipEnabled.value);
 
-    const { hideAllMenus, toggleMenu, closeAllMenus } = useMenuControls(
-        tracks,
-        speed,
-        adjustments,
-    );
+    const { showSurroundMenu, hideAllMenus, toggleMenu, closeAllMenus } =
+        useMenuControls(tracks, speed, adjustments);
 
     const {
         isFullscreenTransitioning,
@@ -177,6 +174,7 @@ export const useAppBootstrap = (coreClient: CoreClient) => {
         isPipEnabled,
         schedulePointerRefresh,
         shouldKeepControlsVisible,
+        showSurroundMenu,
         hideAllMenus,
         toggleMenu,
         closeAllMenus,

--- a/src/composables/useMenuControls.ts
+++ b/src/composables/useMenuControls.ts
@@ -1,4 +1,4 @@
-import type { Ref } from "vue";
+import { ref, type Ref } from "vue";
 
 type MenuRefs = {
     showAudioMenu: Ref<boolean>;
@@ -19,20 +19,24 @@ export const useMenuControls = (
     speed: SpeedRefs,
     settings: SettingsRefs,
 ) => {
+    const showSurroundMenu = ref(false);
+
     const hideAllMenus = () => {
         tracks.showAudioMenu.value = false;
         tracks.showSubMenu.value = false;
         tracks.showSubtitleAdvancedSettings.value = false;
         speed.showSpeedMenu.value = false;
         settings.showSettingsMenu.value = false;
+        showSurroundMenu.value = false;
     };
 
-    const toggleMenu = (menuName: "audio" | "sub" | "speed" | "settings") => {
+    const toggleMenu = (menuName: "audio" | "sub" | "speed" | "settings" | "surround") => {
         const wasOpen = {
             audio: tracks.showAudioMenu.value,
             sub: tracks.showSubMenu.value,
             speed: speed.showSpeedMenu.value,
             settings: settings.showSettingsMenu.value,
+            surround: showSurroundMenu.value,
         };
 
         hideAllMenus();
@@ -49,6 +53,9 @@ export const useMenuControls = (
         if (menuName === "settings" && !wasOpen.settings) {
             settings.showSettingsMenu.value = true;
         }
+        if (menuName === "surround" && !wasOpen.surround) {
+            showSurroundMenu.value = true;
+        }
     };
 
     const closeAllMenus = (event: MouseEvent) => {
@@ -59,6 +66,7 @@ export const useMenuControls = (
     };
 
     return {
+        showSurroundMenu,
         hideAllMenus,
         toggleMenu,
         closeAllMenus,

--- a/src/composables/useSurroundSound.ts
+++ b/src/composables/useSurroundSound.ts
@@ -1,0 +1,312 @@
+import { computed, ref } from "vue";
+import { invoke } from "@tauri-apps/api/core";
+import { loadUiState, saveUiState } from "./useUiStateStore";
+
+export type SurroundPreset = "off" | "movies" | "music" | "gaming" | "custom";
+
+export type SurroundState = {
+    enabled: boolean;
+    preset: SurroundPreset;
+    surroundDepth: number;
+    ambience: number;
+    clarity: number;
+    bassBoost: number;
+    dynamicBoost: number;
+};
+
+type PresetValues = Omit<SurroundState, "enabled" | "preset">;
+
+type StoredSurroundPayload = Partial<SurroundState> & {
+    globalEnabled?: boolean;
+};
+
+export const SURROUND_PRESETS: Record<
+    Exclude<SurroundPreset, "off" | "custom">,
+    PresetValues
+> = {
+    movies: {
+        surroundDepth: 28,
+        ambience: 16,
+        clarity: 45,
+        bassBoost: 35,
+        dynamicBoost: 45,
+    },
+    music: {
+        surroundDepth: 18,
+        ambience: 10,
+        clarity: 58,
+        bassBoost: 32,
+        dynamicBoost: 20,
+    },
+    gaming: {
+        surroundDepth: 34,
+        ambience: 20,
+        clarity: 52,
+        bassBoost: 40,
+        dynamicBoost: 55,
+    },
+};
+
+const DEFAULT_STATE: SurroundState = {
+    enabled: false,
+    preset: "off",
+    surroundDepth: 28,
+    ambience: 16,
+    clarity: 45,
+    bassBoost: 35,
+    dynamicBoost: 30,
+};
+
+const STATE_KEY = "surroundSound";
+const LOCAL_SURROUND_MAX_ENTRIES = 100;
+
+const buildFilterChain = async (state: SurroundState): Promise<string> => {
+    if (!state.enabled) return "";
+    const parts: string[] = [];
+
+    // Dynamic loudness leveling
+    if (state.dynamicBoost > 0) {
+        const gain = Math.round(8 + (state.dynamicBoost / 100) * 16);
+        parts.push(`dynaudnorm=f=150:g=${gain}:p=0.95`);
+    }
+
+    // Stereo field widening (tuned for natural separation without phase hollowness)
+    if (state.surroundDepth > 0) {
+        const width = (1.0 + (state.surroundDepth / 100) * 0.65).toFixed(2);
+        parts.push(`extrastereo=m=${width}`);
+    }
+
+    // Subtle room ambience
+    if (state.ambience > 0) {
+        const delay = Math.round(25 + (state.ambience / 100) * 45);
+        const decay = (0.05 + (state.ambience / 100) * 0.25).toFixed(2);
+        parts.push(`aecho=0.85:0.35:${delay}:${decay}`);
+    }
+
+    // Low-frequency gain
+    if (state.bassBoost > 0) {
+        const gain = ((state.bassBoost / 100) * 12).toFixed(1);
+        parts.push(`bass=g=${gain}`);
+    }
+
+    // High-frequency treble
+    if (state.clarity > 0) {
+        const gain = ((state.clarity / 100) * 8).toFixed(1);
+        parts.push(`treble=g=${gain}`);
+    }
+
+    return parts.join(",");
+};
+
+// Module-level state shared across playback controls and settings
+const globalSurroundEnabled = ref(false);
+const globalSurroundState = ref<SurroundState>({ ...DEFAULT_STATE });
+const localSurroundState = ref<SurroundState>({ ...DEFAULT_STATE });
+const localSurroundByMediaKey = new Map<string, SurroundState>();
+const currentLocalMediaKey = ref("");
+
+const activeSurroundState = computed(() =>
+    globalSurroundEnabled.value
+        ? globalSurroundState.value
+        : localSurroundState.value,
+);
+
+let isLoaded = false;
+let applyTimer: ReturnType<typeof setTimeout> | null = null;
+
+const persistGlobalStateNow = async () => {
+    await saveUiState({
+        [STATE_KEY]: {
+            globalEnabled: globalSurroundEnabled.value,
+            ...globalSurroundState.value,
+        },
+    });
+};
+
+const applyFiltersToMpv = async () => {
+    const filterString = await buildFilterChain(activeSurroundState.value);
+    try {
+        await invoke("mpv_run_command", {
+            args: ["set", "af", filterString],
+        });
+    } catch {
+        // Silently ignore if no media is currently playing
+    }
+};
+
+const scheduleApply = () => {
+    if (applyTimer !== null) clearTimeout(applyTimer);
+    applyTimer = setTimeout(() => {
+        applyTimer = null;
+        void applyFiltersToMpv();
+    }, 80);
+};
+
+export const useSurroundSound = () => {
+    if (!isLoaded) {
+        isLoaded = true;
+        void loadUiState<Record<string, StoredSurroundPayload>>().then(
+            (stored) => {
+                if (stored?.[STATE_KEY]) {
+                    const data = stored[STATE_KEY];
+                    globalSurroundEnabled.value = Boolean(data.globalEnabled);
+                    globalSurroundState.value = {
+                        enabled: Boolean(data.enabled),
+                        preset: data.preset ?? DEFAULT_STATE.preset,
+                        surroundDepth:
+                            data.surroundDepth ?? DEFAULT_STATE.surroundDepth,
+                        ambience: data.ambience ?? DEFAULT_STATE.ambience,
+                        clarity: data.clarity ?? DEFAULT_STATE.clarity,
+                        bassBoost: data.bassBoost ?? DEFAULT_STATE.bassBoost,
+                        dynamicBoost:
+                            data.dynamicBoost ?? DEFAULT_STATE.dynamicBoost,
+                    };
+                }
+                if (
+                    globalSurroundEnabled.value &&
+                    globalSurroundState.value.enabled
+                ) {
+                    void applyFiltersToMpv();
+                }
+            },
+        );
+    }
+
+    const setGlobalSurroundEnabled = async (enabled: boolean) => {
+        globalSurroundEnabled.value = enabled;
+        if (enabled) {
+            // Copy active local state into global state if enabling global
+            globalSurroundState.value = { ...localSurroundState.value };
+        }
+        await persistGlobalStateNow();
+        scheduleApply();
+    };
+
+    const setEnabled = (enabled: boolean) => {
+        const target = globalSurroundEnabled.value
+            ? globalSurroundState
+            : localSurroundState;
+
+        target.value = {
+            ...target.value,
+            enabled,
+            preset: enabled
+                ? target.value.preset === "off"
+                    ? "custom"
+                    : target.value.preset
+                : "off",
+        };
+
+        if (globalSurroundEnabled.value) {
+            void persistGlobalStateNow();
+        } else if (currentLocalMediaKey.value) {
+            localSurroundByMediaKey.set(currentLocalMediaKey.value, {
+                ...target.value,
+            });
+        }
+        scheduleApply();
+    };
+
+    const setPreset = (preset: SurroundPreset) => {
+        const target = globalSurroundEnabled.value
+            ? globalSurroundState
+            : localSurroundState;
+
+        if (preset === "off") {
+            target.value = {
+                ...target.value,
+                enabled: false,
+                preset: "off",
+            };
+        } else if (preset === "custom") {
+            target.value = { ...target.value, preset: "custom" };
+        } else {
+            target.value = {
+                ...target.value,
+                ...SURROUND_PRESETS[preset],
+                enabled: true,
+                preset,
+            };
+        }
+
+        if (globalSurroundEnabled.value) {
+            void persistGlobalStateNow();
+        } else if (currentLocalMediaKey.value) {
+            localSurroundByMediaKey.set(currentLocalMediaKey.value, {
+                ...target.value,
+            });
+        }
+        scheduleApply();
+    };
+
+    const setParam = (key: keyof PresetValues, value: number) => {
+        const target = globalSurroundEnabled.value
+            ? globalSurroundState
+            : localSurroundState;
+
+        target.value = {
+            ...target.value,
+            [key]: value,
+            preset: "custom",
+            enabled: true,
+        };
+
+        if (globalSurroundEnabled.value) {
+            void persistGlobalStateNow();
+        } else if (currentLocalMediaKey.value) {
+            localSurroundByMediaKey.set(currentLocalMediaKey.value, {
+                ...target.value,
+            });
+        }
+        scheduleApply();
+    };
+
+    const applySurroundForMedia = async (mediaKey: string) => {
+        const normalizedKey = mediaKey.trim();
+        currentLocalMediaKey.value = normalizedKey;
+
+        if (globalSurroundEnabled.value) {
+            if (globalSurroundState.value.enabled) {
+                await applyFiltersToMpv();
+            }
+            return;
+        }
+
+        const storedPerMedia = normalizedKey
+            ? localSurroundByMediaKey.get(normalizedKey)
+            : undefined;
+        const perMedia = storedPerMedia ?? DEFAULT_STATE;
+
+        if (normalizedKey && storedPerMedia) {
+            localSurroundByMediaKey.delete(normalizedKey);
+            localSurroundByMediaKey.set(normalizedKey, { ...storedPerMedia });
+        } else if (
+            localSurroundByMediaKey.size > LOCAL_SURROUND_MAX_ENTRIES
+        ) {
+            const oldestKey = localSurroundByMediaKey.keys().next().value;
+            if (oldestKey) localSurroundByMediaKey.delete(oldestKey);
+        }
+
+        localSurroundState.value = { ...perMedia };
+        if (localSurroundState.value.enabled) {
+            await applyFiltersToMpv();
+        }
+    };
+
+    const reapplyFilters = () => {
+        if (activeSurroundState.value.enabled) {
+            void applyFiltersToMpv();
+        }
+    };
+
+    return {
+        surroundState: activeSurroundState,
+        globalSurroundEnabled,
+        setGlobalSurroundEnabled,
+        setEnabled,
+        setPreset,
+        setParam,
+        applySurroundForMedia,
+        reapplyFilters,
+    };
+};

--- a/src/panels/SettingsPanel.vue
+++ b/src/panels/SettingsPanel.vue
@@ -9,6 +9,10 @@ import {
 import RemoteControlQrDialog from "../components/RemoteControlQrDialog.vue";
 import CustomSelect from "../components/CustomSelect.vue";
 import { AUDIO_GROUP_TITLE } from "../composables/settings-sections";
+import {
+    useSurroundSound,
+    type SurroundPreset,
+} from "../composables/useSurroundSound";
 import { getPathDisplayName } from "../utils/getPathDisplayName";
 import {
     ENABLE_COMPACT_MODE_SETTING_LABEL,
@@ -69,6 +73,43 @@ const {
     retryAudioOutput,
     isLoading,
 } = useSettingsPanel();
+
+const {
+    surroundState,
+    globalSurroundEnabled,
+    setGlobalSurroundEnabled,
+    setEnabled: setSurroundEnabled,
+    setPreset: setSurroundPreset,
+    setParam: setSurroundParam,
+} = useSurroundSound();
+
+const SURROUND_SLIDERS = [
+    {
+        key: "surroundDepth" as const,
+        label: "Surround Depth",
+        hint: "Stereo field width",
+    },
+    {
+        key: "ambience" as const,
+        label: "Ambience",
+        hint: "Room reverb / echo",
+    },
+    {
+        key: "clarity" as const,
+        label: "Clarity",
+        hint: "Treble presence",
+    },
+    {
+        key: "bassBoost" as const,
+        label: "Bass Boost",
+        hint: "Low-frequency gain",
+    },
+    {
+        key: "dynamicBoost" as const,
+        label: "Dynamic Boost",
+        hint: "Loudness levelling",
+    },
+];
 
 const audioStatusText = computed(() => {
     const status = audioOutputStatus.value;
@@ -650,6 +691,138 @@ onBeforeUnmount(() => {
                         Retry
                     </button>
                 </div>
+
+                <template v-if="group.title === AUDIO_GROUP_TITLE">
+                    <div class="panel__subtitle panel__subtitle--large">
+                        Virtual Surround Sound
+                    </div>
+                    <div class="panel__table panel__table--card">
+                        <div class="panel__row panel__row--card">
+                            <div class="panel__card-text">
+                                <div class="panel__card-title">Enable 3D Audio</div>
+                                <span class="panel__remote-copy">
+                                    Simulates spatial surround sound on headphones using audio filters
+                                </span>
+                            </div>
+                            <div class="panel__control">
+                                <label class="toggle" style="margin: 0">
+                                    <input
+                                        type="checkbox"
+                                        class="toggle__input"
+                                        :checked="surroundState.enabled"
+                                        aria-label="Enable Virtual Surround Sound"
+                                        @change="
+                                            setSurroundEnabled(
+                                                ($event.target as HTMLInputElement).checked,
+                                            )
+                                        "
+                                    />
+                                    <span class="toggle__track">
+                                        <span class="toggle__thumb"></span>
+                                    </span>
+                                </label>
+                            </div>
+                        </div>
+
+                        <div class="panel__row panel__row--card">
+                            <div class="panel__card-text">
+                                <div class="panel__card-title">Apply Globally</div>
+                                <span class="panel__remote-copy">
+                                    Apply 3D Audio settings across all media and persist on startup
+                                </span>
+                            </div>
+                            <div class="panel__control">
+                                <label class="toggle" style="margin: 0">
+                                    <input
+                                        type="checkbox"
+                                        class="toggle__input"
+                                        :checked="globalSurroundEnabled"
+                                        aria-label="Apply Virtual Surround Sound Globally"
+                                        @change="
+                                            setGlobalSurroundEnabled(
+                                                ($event.target as HTMLInputElement).checked,
+                                            )
+                                        "
+                                    />
+                                    <span class="toggle__track">
+                                        <span class="toggle__thumb"></span>
+                                    </span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div v-if="surroundState.enabled" class="panel__surround-body">
+                        <!-- Preset Pills -->
+                        <div class="panel__surround-presets">
+                            <button
+                                v-for="preset in (['movies', 'music', 'gaming'] as const)"
+                                :key="preset"
+                                class="panel__surround-preset"
+                                :class="{
+                                    'panel__surround-preset--active':
+                                        surroundState.preset === preset,
+                                }"
+                                type="button"
+                                @click="setSurroundPreset(preset as SurroundPreset)"
+                            >
+                                {{ preset.charAt(0).toUpperCase() + preset.slice(1) }}
+                            </button>
+                            <button
+                                class="panel__surround-preset"
+                                :class="{
+                                    'panel__surround-preset--active':
+                                        surroundState.preset === 'custom',
+                                }"
+                                type="button"
+                                @click="setSurroundPreset('custom')"
+                            >
+                                Custom
+                            </button>
+                        </div>
+
+                        <!-- Sliders -->
+                        <div class="panel__surround-sliders">
+                            <div
+                                v-for="slider in SURROUND_SLIDERS"
+                                :key="slider.key"
+                                class="panel__surround-row"
+                            >
+                                <div class="panel__surround-label-col">
+                                    <span class="panel__surround-label">{{
+                                        slider.label
+                                    }}</span>
+                                    <span class="panel__surround-hint">{{
+                                        slider.hint
+                                    }}</span>
+                                </div>
+                                <input
+                                    type="range"
+                                    min="0"
+                                    max="100"
+                                    class="panel__surround-slider"
+                                    :value="surroundState[slider.key]"
+                                    @input="
+                                        setSurroundParam(
+                                            slider.key,
+                                            Number(
+                                                ($event.target as HTMLInputElement).value,
+                                            ),
+                                        )
+                                    "
+                                />
+                                <span class="panel__surround-value">{{
+                                    surroundState[slider.key]
+                                }}</span>
+                            </div>
+                        </div>
+
+                        <p class="panel__surround-tip">
+                            Tip: Best experienced with headphones or stereo speakers.
+                        </p>
+                    </div>
+                </template>
+
                 <template v-if="group.title === 'Playback'">
                     <div class="panel__subtitle panel__subtitle--large">
                         Rendering

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -2694,3 +2694,169 @@
     color: var(--panel-muted, rgba(255, 255, 255, 0.68));
     font-size: 12px;
 }
+
+/* ─── Virtual Surround Sound & Audio Filter Panels ────────────────────── */
+
+.panel__surround-body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 14px 16px 16px;
+    border-radius: 10px;
+    margin: 8px 0 0;
+    background: rgba(0, 0, 0, 0.04);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.panel__surround-presets {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.panel__surround-preset {
+    padding: 5px 14px;
+    border-radius: 20px;
+    border: 1px solid rgba(0, 0, 0, 0.16);
+    background: rgba(0, 0, 0, 0.05);
+    color: rgba(0, 0, 0, 0.65);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    font-family: inherit;
+}
+
+.panel__surround-preset:hover {
+    background: rgba(0, 0, 0, 0.1);
+    color: rgba(0, 0, 0, 0.82);
+}
+
+.panel__surround-preset--active {
+    background: rgba(99, 102, 241, 0.15);
+    border-color: rgba(99, 102, 241, 0.45);
+    color: rgba(79, 70, 229, 0.9);
+}
+
+.panel__surround-sliders {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.panel__surround-row {
+    display: grid;
+    grid-template-columns: 130px 1fr 36px;
+    align-items: center;
+    gap: 10px;
+}
+
+.panel__surround-label-col {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+.panel__surround-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: rgba(0, 0, 0, 0.78);
+    line-height: 1.2;
+}
+
+.panel__surround-hint {
+    font-size: 10px;
+    color: rgba(0, 0, 0, 0.42);
+    line-height: 1.2;
+}
+
+.panel__surround-slider {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 4px;
+    border-radius: 2px;
+    background: rgba(0, 0, 0, 0.14);
+    outline: none;
+    cursor: pointer;
+    accent-color: rgb(99, 102, 241);
+}
+
+.panel__surround-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: rgb(99, 102, 241);
+    cursor: pointer;
+    box-shadow: 0 1px 4px rgba(99, 102, 241, 0.4);
+    transition: transform 0.12s;
+}
+
+.panel__surround-slider::-webkit-slider-thumb:hover {
+    transform: scale(1.2);
+}
+
+.panel__surround-value {
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum";
+    color: rgba(0, 0, 0, 0.55);
+    text-align: right;
+    min-width: 28px;
+}
+
+.panel__surround-tip {
+    font-size: 11px;
+    color: rgba(0, 0, 0, 0.4);
+    margin: 0;
+    line-height: 1.5;
+    padding: 8px 10px;
+    background: rgba(255, 180, 0, 0.07);
+    border-radius: 6px;
+    border-left: 3px solid rgba(255, 180, 0, 0.4);
+}
+
+:root:is([data-theme="dark"], [data-theme="graphite"]) .panel__surround-body {
+    background: rgba(255, 255, 255, 0.03);
+    border-color: rgba(255, 255, 255, 0.08);
+}
+
+:root:is([data-theme="dark"], [data-theme="graphite"]) .panel__surround-preset {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.6);
+}
+
+:root:is([data-theme="dark"], [data-theme="graphite"]) .panel__surround-preset:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.85);
+}
+
+:root:is([data-theme="dark"], [data-theme="graphite"]) .panel__surround-preset--active {
+    background: rgba(99, 102, 241, 0.2);
+    border-color: rgba(129, 140, 248, 0.5);
+    color: rgba(165, 180, 252, 0.95);
+}
+
+:root:is([data-theme="dark"], [data-theme="graphite"]) .panel__surround-label {
+    color: rgba(255, 255, 255, 0.82);
+}
+
+:root:is([data-theme="dark"], [data-theme="graphite"]) .panel__surround-hint {
+    color: rgba(255, 255, 255, 0.36);
+}
+
+:root:is([data-theme="dark"], [data-theme="graphite"]) .panel__surround-slider {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+:root:is([data-theme="dark"], [data-theme="graphite"]) .panel__surround-value {
+    color: rgba(255, 255, 255, 0.45);
+}
+
+:root:is([data-theme="dark"], [data-theme="graphite"]) .panel__surround-tip {
+    color: rgba(255, 255, 255, 0.35);
+    background: rgba(255, 180, 0, 0.06);
+    border-left-color: rgba(255, 180, 0, 0.3);
+}


### PR DESCRIPTION
Hi @FengZeng, here is the dedicated PR for the **3D Virtual Surround Sound & Audio Filters** feature.

### Summary of Changes

- **Virtual 3D Audio & DSP Filters**: Implemented an MPV audio filter pipeline (`af`) combining:
  - **Dynamic Loudness Leveling** (`dynaudnorm`) for consistent volume without clipping.
  - **Stereo Widening / Surround Depth** (`extrastereo`) tuned for expansive soundstage without phase cancellation.
  - **Room Ambience & Reverb** (`aecho`) for spatial presence on headphones and stereo speakers.
  - **Bass Boost & Treble Clarity** (`bass`, `treble`) for enhanced low-end and vocal clarity.
- **Audio Presets**: Added presets (`Movies`, `Music`, `Gaming`, `Custom`) with tuned parameters.
- **Player Controls & Settings Integration**:
  - Added a dedicated **3D Audio** button and popup menu in the bottom playback control bar.
  - Added a **Virtual Surround Sound** card under the **Audio** tab in the Settings panel (both UI locations are fully synchronized).
- **Global & Per-Media Persistence**: Added a `Global` toggle to apply audio filter settings across all media and persist state in `state.json` via Tauri across app restarts.

### Verification

- Tested real-time audio filter changes across stereo headphones and speakers.
- Verified smooth filter application without audio stutter or lag.
- Verified state persistence across media switches and application restarts.
- Passed `cargo check` and `vite build` with 0 errors.

<img width="281" height="409" alt="image" src="https://github.com/user-attachments/assets/7be9e244-3aff-4101-b7f6-55f84d8bc46f" />
